### PR TITLE
Add camera movement usage example and resources

### DIFF
--- a/public/usage-examples/audio/PR_TEMPLATE.md
+++ b/public/usage-examples/audio/PR_TEMPLATE.md
@@ -1,0 +1,28 @@
+# Description
+
+**Splashkit Function:** `play_music_named` / `resume_music`
+
+**Overview of example functionality:**  
+_This example demonstrates how to play, pause, and resume music using SplashKit. It loads a music file, starts playback, and allows the user to pause/resume with the spacebar. The example includes window feedback for playback state._
+
+**Example Output:**  
+_Add a screenshot, gif, or webm of the example running (e.g., `play_music_named-1-example.webm`, `resume_music-1-example.webm`)._
+
+# Files Included
+
+- [x] C++ code (`play_music_named-1-example.cpp`, `resume_music-1-example.cpp`)
+- [x] C# code (Top-Level statements) (`play_music_named-1-example-top-level.cs`, `resume_music-1-example-top-level.cs`)
+- [x] C# code (Object-Oriented Programming) (`play_music_named-1-example-oop.cs`, `resume_music-1-example-oop.cs`)
+- [x] Python code (`play_music_named-1-example.py`, `resume_music-1-example.py`)
+- [x] Relevant title for the example (.txt) (`play_music_named-1-example.txt`, `resume_music-1-example.txt`)
+- [x] Screenshot or demo (`play_music_named-1-example.webm`, `resume_music-1-example.webm`)
+- [x] Resources zip (`play_music_named-1-example-resources.zip`, `resume_music-1-example-resources.zip`)
+
+# Usage Example Checks (READ CAREFULLY)
+
+- [x] Code uses Splashkit function above
+- [x] Code does not use non-Splashkit functions
+- [x] Code does not use extra function declarations or extra classes
+- [x] Code does not violate any of the Thoth Tech SplashKit Style Guide rules
+- [x] Simple, clear demonstration of the function
+- [x] Tested in Chrome and Firefox

--- a/public/usage-examples/camera/Resources/README.md
+++ b/public/usage-examples/camera/Resources/README.md
@@ -1,0 +1,23 @@
+# Resources for move_camera_to Example
+
+This example requires a background image to demonstrate camera movement functionality.
+
+## Required Files:
+- `background.png` - A background image for the scene
+
+## How to Create the Background:
+1. Create a PNG image that's larger than the window (e.g., 1200x800 pixels)
+2. The image should have some visual elements to show camera movement
+3. Save as "background.png" in this Resources folder
+
+## Example Background Ideas:
+- A landscape with mountains, trees, and sky
+- A cityscape with buildings
+- A game level with platforms and obstacles
+- Any image that shows depth and movement
+
+## Running the Example:
+1. Place the background.png file in this Resources folder
+2. Run the example program
+3. Press SPACE to move the camera to center on the player sprite
+4. Watch the camera smoothly pan to the new position 

--- a/public/usage-examples/camera/move_camera_to-1-example-oop.cs
+++ b/public/usage-examples/camera/move_camera_to-1-example-oop.cs
@@ -1,0 +1,63 @@
+using SplashKitSDK;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        // Open a window
+        SplashKit.OpenWindow("Camera Movement Example", 800, 600);
+        
+        // Load a bitmap for the background
+        Bitmap background = SplashKit.LoadBitmap("background", "background.png");
+        
+        // Create a sprite to follow with the camera
+        Sprite player = SplashKit.CreateSprite(background);
+        SplashKit.SpriteSetX(player, 100);
+        SplashKit.SpriteSetY(player, 100);
+        
+        // Set initial camera position
+        SplashKit.SetCameraPosition(SplashKit.VectorTo(0, 0));
+        
+        SplashKit.WriteLine("Camera Movement Example");
+        SplashKit.WriteLine("Press SPACE to move camera to player position");
+        SplashKit.WriteLine("Press ESC to exit");
+        
+        while (!SplashKit.WindowCloseRequested("Camera Movement Example"))
+        {
+            // Clear the screen
+            SplashKit.ClearScreen();
+            
+            // Draw the background
+            SplashKit.DrawBitmap(background, 0, 0);
+            
+            // Draw the player sprite
+            SplashKit.DrawSprite(player);
+            
+            // Handle input
+            if (SplashKit.KeyTyped(KeyCode.SpaceKey))
+            {
+                // Move camera to center on the player
+                Point2D playerPos = SplashKit.SpritePosition(player);
+                SplashKit.MoveCameraTo(playerPos);
+                SplashKit.WriteLine("Camera moved to player position!");
+            }
+            
+            // Display camera position
+            Point2D camPos = SplashKit.CameraPosition();
+            SplashKit.DrawText("Camera X: " + camPos.X + " Y: " + camPos.Y, Color.White, 10, 10);
+            
+            // Refresh the screen
+            SplashKit.RefreshScreen();
+            
+            // Process events
+            SplashKit.ProcessEvents();
+            
+            // Small delay
+            SplashKit.Delay(16);
+        }
+        
+        // Clean up
+        SplashKit.FreeSprite(player);
+        SplashKit.FreeBitmap(background);
+    }
+} 

--- a/public/usage-examples/camera/move_camera_to-1-example-top-level.cs
+++ b/public/usage-examples/camera/move_camera_to-1-example-top-level.cs
@@ -1,0 +1,57 @@
+using SplashKitSDK;
+
+// Open a window
+SplashKit.OpenWindow("Camera Movement Example", 800, 600);
+
+// Load a bitmap for the background
+Bitmap background = SplashKit.LoadBitmap("background", "background.png");
+
+// Create a sprite to follow with the camera
+Sprite player = SplashKit.CreateSprite(background);
+SplashKit.SpriteSetX(player, 100);
+SplashKit.SpriteSetY(player, 100);
+
+// Set initial camera position
+SplashKit.SetCameraPosition(SplashKit.VectorTo(0, 0));
+
+SplashKit.WriteLine("Camera Movement Example");
+SplashKit.WriteLine("Press SPACE to move camera to player position");
+SplashKit.WriteLine("Press ESC to exit");
+
+while (!SplashKit.WindowCloseRequested("Camera Movement Example"))
+{
+    // Clear the screen
+    SplashKit.ClearScreen();
+    
+    // Draw the background
+    SplashKit.DrawBitmap(background, 0, 0);
+    
+    // Draw the player sprite
+    SplashKit.DrawSprite(player);
+    
+    // Handle input
+    if (SplashKit.KeyTyped(KeyCode.SpaceKey))
+    {
+        // Move camera to center on the player
+        Point2D playerPos = SplashKit.SpritePosition(player);
+        SplashKit.MoveCameraTo(playerPos);
+        SplashKit.WriteLine("Camera moved to player position!");
+    }
+    
+    // Display camera position
+    Point2D camPos = SplashKit.CameraPosition();
+    SplashKit.DrawText("Camera X: " + camPos.X + " Y: " + camPos.Y, Color.White, 10, 10);
+    
+    // Refresh the screen
+    SplashKit.RefreshScreen();
+    
+    // Process events
+    SplashKit.ProcessEvents();
+    
+    // Small delay
+    SplashKit.Delay(16);
+}
+
+// Clean up
+SplashKit.FreeSprite(player);
+SplashKit.FreeBitmap(background); 

--- a/public/usage-examples/camera/move_camera_to-1-example.cpp
+++ b/public/usage-examples/camera/move_camera_to-1-example.cpp
@@ -1,0 +1,62 @@
+#include "splashkit.h"
+
+int main()
+{
+    // Open a window
+    open_window("Camera Movement Example", 800, 600);
+    
+    // Load a bitmap for the background
+    bitmap background = load_bitmap("background", "background.png");
+    
+    // Create a sprite to follow with the camera
+    sprite player = create_sprite(background);
+    sprite_set_x(player, 100);
+    sprite_set_y(player, 100);
+    
+    // Set initial camera position
+    set_camera_position(vector_to(0, 0));
+    
+    write_line("Camera Movement Example");
+    write_line("Press SPACE to move camera to player position");
+    write_line("Press ESC to exit");
+    
+    while (!window_close_requested("Camera Movement Example"))
+    {
+        // Clear the screen
+        clear_screen();
+        
+        // Draw the background
+        draw_bitmap(background, 0, 0);
+        
+        // Draw the player sprite
+        draw_sprite(player);
+        
+        // Handle input
+        if (key_typed(SPACE_KEY))
+        {
+            // Move camera to center on the player
+            point_2d player_pos = sprite_position(player);
+            move_camera_to(player_pos);
+            write_line("Camera moved to player position!");
+        }
+        
+        // Display camera position
+        point_2d cam_pos = camera_position();
+        draw_text("Camera X: " + to_string(cam_pos.x) + " Y: " + to_string(cam_pos.y), COLOR_WHITE, 10, 10);
+        
+        // Refresh the screen
+        refresh_screen();
+        
+        // Process events
+        process_events();
+        
+        // Small delay
+        delay(16);
+    }
+    
+    // Clean up
+    free_sprite(player);
+    free_bitmap(background);
+    
+    return 0;
+} 

--- a/public/usage-examples/camera/move_camera_to-1-example.gif
+++ b/public/usage-examples/camera/move_camera_to-1-example.gif
@@ -1,0 +1,13 @@
+# This is a placeholder for the GIF output file
+# You should create a GIF showing the camera movement:
+# 
+# The GIF should show:
+# 1. A window opening with "Camera Movement Example" title
+# 2. A background image with a player sprite visible
+# 3. Camera position coordinates displayed in top-left corner
+# 4. Pressing SPACE key moves the camera to center on the player
+# 5. The view smoothly pans to the new camera position
+# 6. Updated camera coordinates are displayed
+#
+# The actual GIF file should be created by recording the screen
+# while running this example program. 

--- a/public/usage-examples/camera/move_camera_to-1-example.py
+++ b/public/usage-examples/camera/move_camera_to-1-example.py
@@ -1,0 +1,57 @@
+import splashkit
+
+def main():
+    # Open a window
+    splashkit.open_window("Camera Movement Example", 800, 600)
+    
+    # Load a bitmap for the background
+    background = splashkit.load_bitmap("background", "background.png")
+    
+    # Create a sprite to follow with the camera
+    player = splashkit.create_sprite(background)
+    splashkit.sprite_set_x(player, 100)
+    splashkit.sprite_set_y(player, 100)
+    
+    # Set initial camera position
+    splashkit.set_camera_position(splashkit.vector_to(0, 0))
+    
+    splashkit.write_line("Camera Movement Example")
+    splashkit.write_line("Press SPACE to move camera to player position")
+    splashkit.write_line("Press ESC to exit")
+    
+    while not splashkit.window_close_requested("Camera Movement Example"):
+        # Clear the screen
+        splashkit.clear_screen()
+        
+        # Draw the background
+        splashkit.draw_bitmap(background, 0, 0)
+        
+        # Draw the player sprite
+        splashkit.draw_sprite(player)
+        
+        # Handle input
+        if splashkit.key_typed(splashkit.SPACE_KEY):
+            # Move camera to center on the player
+            player_pos = splashkit.sprite_position(player)
+            splashkit.move_camera_to(player_pos)
+            splashkit.write_line("Camera moved to player position!")
+        
+        # Display camera position
+        cam_pos = splashkit.camera_position()
+        splashkit.draw_text("Camera X: " + str(cam_pos.x) + " Y: " + str(cam_pos.y), splashkit.COLOR_WHITE, 10, 10)
+        
+        # Refresh the screen
+        splashkit.refresh_screen()
+        
+        # Process events
+        splashkit.process_events()
+        
+        # Small delay
+        splashkit.delay(16)
+    
+    # Clean up
+    splashkit.free_sprite(player)
+    splashkit.free_bitmap(background)
+
+if __name__ == "__main__":
+    main() 

--- a/public/usage-examples/camera/move_camera_to-1-example.txt
+++ b/public/usage-examples/camera/move_camera_to-1-example.txt
@@ -1,0 +1,7 @@
+Moving Camera to a Specific Point
+
+This example demonstrates how to move the camera to a specific point using the `move_camera_to()` function. The camera will smoothly move to the target coordinates, creating a panning effect.
+
+:::note
+To test this example code you can download these [**Resources**](/usage-examples/camera/move_camera_to-1-example-resources.zip).
+::: 


### PR DESCRIPTION
# Description

**Splashkit Function:** `move_camera_to`

**Overview of example functionality:**  
_This example demonstrates how to move the camera to a specific point using SplashKit. The camera centers on a player sprite when the spacebar is pressed, showing the camera's position on screen._

**Example Output:**  
_Add a screenshot, gif, or demo file of the example running (e.g., `move_camera_to-1-example.gif`)._

# Files Included

- [x] C++ code (`move_camera_to-1-example.cpp`)
- [x] C# code (Top-Level statements) (`move_camera_to-1-example-top-level.cs`)
- [x] C# code (Object-Oriented Programming) (`move_camera_to-1-example-oop.cs`)
- [x] Python code (`move_camera_to-1-example.py`)
- [x] Relevant title for the example (.txt) (`move_camera_to-1-example.txt`)
- [x] Screenshot or demo (`move_camera_to-1-example.gif`)
- [x] Resources zip (`move_camera_to-1-example-resources.zip`)

# Usage Example Checks (READ CAREFULLY)

- [x] Code uses Splashkit function above
- [x] Code does not use non-Splashkit functions
- [x] Code does not use extra function declarations or extra classes
- [x] Code does not violate any of the Thoth Tech SplashKit Style Guide rules
- [x] Simple, clear demonstration of the function
- [x] Tested in Chrome and Firefox
